### PR TITLE
Added Java/JVM and JavaScript development tool installation scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,11 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# JetBrain tools
+.idea
+*.ipr
+*.iml
+
+# VIm
+*.swp

--- a/install/README.md
+++ b/install/README.md
@@ -1,0 +1,40 @@
+# Scripts to install standard development tools
+These are shell scripts to install up-to-date standard Java/JVM and JS development
+tools and tool management systems.  All scripts are re-runnable and should not
+re-install versions already present.
+
+## Pre-Requisites
+
+- Linux distribution (tested on Ubuntu 16.04 but should work on any distro)
+- BASH shell
+- CURL command-line tool
+- Java Development Kit (JDK) 1.8.0 (tested with OpenJDK 1.8.0u111)
+
+## Scripts
+
+Scripts do not take any command-line parameters.  __Eclipse__ and __JetBrains__ tools
+will be installed under ```$HOME/tools```.
+
+### eclipse.sh
+- Installs the Neon version of __Eclipse of Java developers__
+- Creates a launcher icon for the above
+
+### jetbrains_toolbox.sh
+- Installs v1.1.2143 of the __JetBrains Toolbox__ that manages installation of
+  __IntelliJ IDEA__ and related tools.
+- Runs the tool and installs an icon in the launcher
+
+### sdkman.sh
+- Installs the latest version of the __sdkman__ (formerly Groovy Version Manager)
+  installation tool for JVM build tools and libraries
+  - Updates to the latest version of __sdkman__ if already installed
+- Installs __Groovy__ v2.4.7
+- Installs __Gradle__ 3.3
+- Installs __Maven__ 3.3.9
+
+### nvm.sh
+- Installs the latest version of __NVM__ (Node Verison Manager) for managing
+  installations of __Node.JS__ and __IO.JS__
+- Installs __Node.JS__ v6.9.4 and tools related to that version:
+  - Installs __Bower__ CLI v1.8.0
+  - Installs __Grunt__ CLI v1.2.0

--- a/install/eclipse.sh
+++ b/install/eclipse.sh
@@ -35,6 +35,7 @@ if [ ! -x "$OUTDIR/java-neon" ]; then
         echo "Terminal=false" >> $ICONFILE
     else
         echo "Invalid checksum for tarball.  Aborting."
+        exit 1
     fi
 
     rm -r $TMPDIR
@@ -43,3 +44,4 @@ else
     echo "To remove it and re-install run rm -rf $OUTDIR/java-neon"
 fi
 
+exit 0

--- a/install/eclipse.sh
+++ b/install/eclipse.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Installer for JetBrains Toolbox
+# This will allow the installation, upgrade and management of other JetBrains tools
+# Running the tool itself will automatically add an icon to the launcher
+
+TMPDIR=~/tools/tmp
+OUTDIR=~/tools/eclipse
+CHECKSUM="7cd7c5a020bb4a8644fdaa1b4e3b1b9daab34edd17677e28b2cdd7934f2a6432320fbba241e4fb91349ae056405721522e4bfe29970a3934d49a3e8385558691"
+ICONFILE=~/.local/share/applications/eclipse.desktop
+
+mkdir -p $OUTDIR
+mkdir -p $TMPDIR
+
+curl -L http://www.mirrorservice.org/sites/download.eclipse.org/eclipseMirror/technology/epp/downloads/release/neon/2/eclipse-java-neon-2-linux-gtk-x86_64.tar.gz -o $TMPDIR/eclipse.tar.gz
+if [ "`sha512sum $TMPDIR/eclipse.tar.gz`" == "$CHECKSUM  $TMPDIR/eclipse.tar.gz" ]; then
+    cd $OUTDIR
+    tar xvzf $TMPDIR/eclipse.tar.gz
+    rm -rf $OUTDIR/java-neon
+    rm -f $OUTDIR/current
+    mv $OUTDIR/eclipse $OUTDIR/java-neon
+    ln -s $OUTDIR/java-neon $OUTDIR/current
+
+    rm -f $ICONFILE
+    echo "[Desktop Entry]" > $ICONFILE
+    echo "Type=Application" >> $ICONFILE
+    echo "Name=Eclipse Neon" >> $ICONFILE
+    echo "Exec=$HOME/tools/eclipse/current/eclipse %u" >> $ICONFILE
+    echo "Icon=$HOME/tools/eclipse/current/icon.xpm" >> $ICONFILE
+    echo "StartupNotify=false" >> $ICONFILE
+    echo "Categories=Development;IDE;" >> $ICONFILE
+    echo "Terminal=false" >> $ICONFILE
+else
+    echo "Unexpected checksum in tarball"
+fi
+
+rm -r $TMPDIR

--- a/install/eclipse.sh
+++ b/install/eclipse.sh
@@ -9,29 +9,36 @@ OUTDIR=~/tools/eclipse
 CHECKSUM="7cd7c5a020bb4a8644fdaa1b4e3b1b9daab34edd17677e28b2cdd7934f2a6432320fbba241e4fb91349ae056405721522e4bfe29970a3934d49a3e8385558691"
 ICONFILE=~/.local/share/applications/eclipse.desktop
 
-mkdir -p $OUTDIR
-mkdir -p $TMPDIR
+if [ ! -x "$OUTDIR/java-neon" ]; then
 
-curl -L http://www.mirrorservice.org/sites/download.eclipse.org/eclipseMirror/technology/epp/downloads/release/neon/2/eclipse-java-neon-2-linux-gtk-x86_64.tar.gz -o $TMPDIR/eclipse.tar.gz
-if [ "`sha512sum $TMPDIR/eclipse.tar.gz`" == "$CHECKSUM  $TMPDIR/eclipse.tar.gz" ]; then
-    cd $OUTDIR
-    tar xvzf $TMPDIR/eclipse.tar.gz
-    rm -rf $OUTDIR/java-neon
-    rm -f $OUTDIR/current
-    mv $OUTDIR/eclipse $OUTDIR/java-neon
-    ln -s $OUTDIR/java-neon $OUTDIR/current
+    mkdir -p $OUTDIR
+    mkdir -p $TMPDIR
 
-    rm -f $ICONFILE
-    echo "[Desktop Entry]" > $ICONFILE
-    echo "Type=Application" >> $ICONFILE
-    echo "Name=Eclipse Neon" >> $ICONFILE
-    echo "Exec=$HOME/tools/eclipse/current/eclipse %u" >> $ICONFILE
-    echo "Icon=$HOME/tools/eclipse/current/icon.xpm" >> $ICONFILE
-    echo "StartupNotify=false" >> $ICONFILE
-    echo "Categories=Development;IDE;" >> $ICONFILE
-    echo "Terminal=false" >> $ICONFILE
+    curl -L http://www.mirrorservice.org/sites/download.eclipse.org/eclipseMirror/technology/epp/downloads/release/neon/2/eclipse-java-neon-2-linux-gtk-x86_64.tar.gz -o $TMPDIR/eclipse.tar.gz
+    if [ "`sha512sum $TMPDIR/eclipse.tar.gz`" == "$CHECKSUM  $TMPDIR/eclipse.tar.gz" ]; then
+        cd $OUTDIR
+        rm -rf $OUTDIR/eclipse
+        tar xvzf $TMPDIR/eclipse.tar.gz
+        rm -f $OUTDIR/current
+        mv $OUTDIR/eclipse $OUTDIR/java-neon
+        ln -s $OUTDIR/java-neon $OUTDIR/current
+
+        rm -f $ICONFILE
+        echo "[Desktop Entry]" > $ICONFILE
+        echo "Type=Application" >> $ICONFILE
+        echo "Name=Eclipse Neon" >> $ICONFILE
+        echo "Exec=$OUTDIR/current/eclipse %u" >> $ICONFILE
+        echo "Icon=$OUTDIR/current/icon.xpm" >> $ICONFILE
+        echo "StartupNotify=false" >> $ICONFILE
+        echo "Categories=Development;IDE;" >> $ICONFILE
+        echo "Terminal=false" >> $ICONFILE
+    else
+        echo "Invalid checksum for tarball.  Aborting."
+    fi
+
+    rm -r $TMPDIR
 else
-    echo "Unexpected checksum in tarball"
+    echo "Eclipse Neon is already installed"
+    echo "To remove it and re-install run rm -rf $OUTDIR/java-neon"
 fi
 
-rm -r $TMPDIR

--- a/install/eclipse.sh
+++ b/install/eclipse.sh
@@ -16,7 +16,7 @@ if [ ! -x "$OUTDIR/java-neon" ]; then
     mkdir -p $TMPDIR
 
     curl -L http://www.mirrorservice.org/sites/download.eclipse.org/eclipseMirror/technology/epp/downloads/release/neon/2/eclipse-java-neon-2-linux-gtk-x86_64.tar.gz -o $TMPDIR/eclipse.tar.gz
-    if [ "`sha512sum $TMPDIR/eclipse.tar.gz`" == "$CHECKSUM  $TMPDIR/eclipse.tar.gz" ]; then
+    if [ "$(sha512sum $TMPDIR/eclipse.tar.gz)" == "$CHECKSUM  $TMPDIR/eclipse.tar.gz" ]; then
         cd $OUTDIR
         rm -rf $OUTDIR/eclipse
         tar xvzf $TMPDIR/eclipse.tar.gz

--- a/install/eclipse.sh
+++ b/install/eclipse.sh
@@ -5,10 +5,10 @@ set -euo pipefail
 # This will allow the installation, upgrade and management of other JetBrains tools
 # Running the tool itself will automatically add an icon to the launcher
 
-TMPDIR=~/tools/tmp
-OUTDIR=~/tools/eclipse
+TMPDIR=$HOME/tools/tmp
+OUTDIR=$HOME/tools/eclipse
 CHECKSUM="7cd7c5a020bb4a8644fdaa1b4e3b1b9daab34edd17677e28b2cdd7934f2a6432320fbba241e4fb91349ae056405721522e4bfe29970a3934d49a3e8385558691"
-ICONFILE=~/.local/share/applications/eclipse.desktop
+ICONFILE=$HOME/.local/share/applications/eclipse.desktop
 
 if [ ! -x "$OUTDIR/java-neon" ]; then
 

--- a/install/eclipse.sh
+++ b/install/eclipse.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Installer for JetBrains Toolbox
 # This will allow the installation, upgrade and management of other JetBrains tools

--- a/install/jetbrains_toolbox.sh
+++ b/install/jetbrains_toolbox.sh
@@ -7,16 +7,27 @@
 VERSION=1.1.2143
 TMPDIR=~/tools/tmp
 OUTDIR=~/tools/jetbrains
+CHECKSUM="74ca89a1b97367e909075e53c67ee093ca316ecb8124bb39e7318750634552a3"
 
-mkdir -p $OUTDIR
-mkdir -p $TMPDIR
+if [ ! -x "$OUTDIR/jetbrains-toolbox-$VERSION" ]; then
+    mkdir -p $TMPDIR
 
-curl -L https://download.jetbrains.com/toolbox/jetbrains-toolbox-${VERSION}.tar.gz -o $TMPDIR/jetbrains-toolbox.tar.gz
-cd $OUTDIR
-tar xvzf $TMPDIR/jetbrains-toolbox.tar.gz
-rm -f $OUTDIR/latest
-ln -s $OUTDIR/*$VERSION* $OUTDIR/latest
+    curl -L https://download.jetbrains.com/toolbox/jetbrains-toolbox-${VERSION}.tar.gz -o $TMPDIR/jetbrains-toolbox.tar.gz
 
-rm -r $TMPDIR
+    if [ "`sha256sum $TMPDIR/jetbrains-toolbox.tar.gz`" == "$CHECKSUM  $TMPDIR/jetbrains-toolbox.tar.gz" ]; then
+        mkdir -p $OUTDIR
+        cd $OUTDIR
+        tar xvzf $TMPDIR/jetbrains-toolbox.tar.gz
+        rm -f $OUTDIR/latest
+        ln -s $OUTDIR/jetbrains-toolbox-$VERSION $OUTDIR/latest
+    else
+        echo "Invalid checksum for tarball.  Aborting."
+    fi
 
-$OUTDIR/latest/jetbrains-toolbox &
+    rm -r $TMPDIR
+
+    $OUTDIR/latest/jetbrains-toolbox &
+else
+    echo "JetBrains Toolbox $VERSION is already installed"
+    echo "To remove it, run rm -rf $OUTDIR/jetbrains-toolbox-$VERSION"
+fi

--- a/install/jetbrains_toolbox.sh
+++ b/install/jetbrains_toolbox.sh
@@ -15,7 +15,7 @@ if [ ! -x "$OUTDIR/jetbrains-toolbox-$VERSION" ]; then
 
     curl -L https://download.jetbrains.com/toolbox/jetbrains-toolbox-${VERSION}.tar.gz -o $TMPDIR/jetbrains-toolbox.tar.gz
 
-    if [ "`sha256sum $TMPDIR/jetbrains-toolbox.tar.gz`" == "$CHECKSUM  $TMPDIR/jetbrains-toolbox.tar.gz" ]; then
+    if [ "$(sha256sum $TMPDIR/jetbrains-toolbox.tar.gz)" == "$CHECKSUM  $TMPDIR/jetbrains-toolbox.tar.gz" ]; then
         mkdir -p $OUTDIR
         cd $OUTDIR
         tar xvzf $TMPDIR/jetbrains-toolbox.tar.gz

--- a/install/jetbrains_toolbox.sh
+++ b/install/jetbrains_toolbox.sh
@@ -29,5 +29,5 @@ if [ ! -x "$OUTDIR/jetbrains-toolbox-$VERSION" ]; then
     $OUTDIR/latest/jetbrains-toolbox &
 else
     echo "JetBrains Toolbox $VERSION is already installed"
-    echo "To remove it, run rm -rf $OUTDIR/jetbrains-toolbox-$VERSION"
+    echo "To remove it and re-install run rm -rf $OUTDIR/jetbrains-toolbox-$VERSION"
 fi

--- a/install/jetbrains_toolbox.sh
+++ b/install/jetbrains_toolbox.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 # Running the tool itself will automatically add an icon to the launcher
 
 VERSION=1.1.2143
-TMPDIR=~/tools/tmp
-OUTDIR=~/tools/jetbrains
+TMPDIR=$HOME/tools/tmp
+OUTDIR=$HOME/tools/jetbrains
 CHECKSUM="74ca89a1b97367e909075e53c67ee093ca316ecb8124bb39e7318750634552a3"
 
 if [ ! -x "$OUTDIR/jetbrains-toolbox-$VERSION" ]; then

--- a/install/jetbrains_toolbox.sh
+++ b/install/jetbrains_toolbox.sh
@@ -23,6 +23,7 @@ if [ ! -x "$OUTDIR/jetbrains-toolbox-$VERSION" ]; then
         ln -s $OUTDIR/jetbrains-toolbox-$VERSION $OUTDIR/latest
     else
         echo "Invalid checksum for tarball.  Aborting."
+        exit 1
     fi
 
     rm -r $TMPDIR
@@ -32,3 +33,5 @@ else
     echo "JetBrains Toolbox $VERSION is already installed"
     echo "To remove it and re-install run rm -rf $OUTDIR/jetbrains-toolbox-$VERSION"
 fi
+
+exit 0

--- a/install/jetbrains_toolbox.sh
+++ b/install/jetbrains_toolbox.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Installer for JetBrains Toolbox
 # This will allow the installation, upgrade and management of other JetBrains tools

--- a/install/nvm.sh
+++ b/install/nvm.sh
@@ -5,7 +5,7 @@ fi
 
 if [ "`nvm --version`" == '' ]; then
     echo Loading config
-    export NVM_DIR="/home/krupag/.nvm"
+    export NVM_DIR="$HOME/.nvm"
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 fi
 
@@ -26,6 +26,6 @@ if [ "`grunt --version`" != 'grunt-cli v1.2.0' ]; then
 fi
 
 echo Close and reopen your terminal to start using nvm or run the following to use it now:
-echo export NVM_DIR="/home/krupag/.nvm"
+echo export NVM_DIR="$HOME/.nvm"
 echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm'
 

--- a/install/nvm.sh
+++ b/install/nvm.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 if [ ! -x "$HOME/.nvm" ]; then
     curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
 fi

--- a/install/nvm.sh
+++ b/install/nvm.sh
@@ -5,24 +5,24 @@ if [ ! -x "$HOME/.nvm" ]; then
     curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
 fi
 
-if [ "`nvm --version`" == '' ]; then
+if [ "$(nvm --version)" == '' ]; then
     echo Loading config
     export NVM_DIR="$HOME/.nvm"
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 fi
 
-if [ "`node --version`" != 'v6.9.4' ]; then
+if [ "$(node --version)" != 'v6.9.4' ]; then
     echo Installing NodeJS
     nvm install v6.9.4
     nvm use v6.9.4
 fi
 
-if [ "`bower --version`" != '1.8.0' ]; then
+if [ "$(bower --version)" != '1.8.0' ]; then
     echo Installing Bower
     npm install -g bower@1.8.0
 fi
 
-if [ "`grunt --version`" != 'grunt-cli v1.2.0' ]; then
+if [ "$(grunt --version)" != 'grunt-cli v1.2.0' ]; then
     echo Installing Grunt
     npm install -g grunt-cli@1.2.0
 fi

--- a/install/nvm.sh
+++ b/install/nvm.sh
@@ -8,13 +8,17 @@ fi
 if [ "$(nvm --version)" == '' ]; then
     echo Loading config
     export NVM_DIR="$HOME/.nvm"
+    set +eu
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+    set -eu
 fi
 
 if [ "$(node --version)" != 'v6.9.4' ]; then
     echo Installing NodeJS
+    set +u
     nvm install v6.9.4
     nvm use v6.9.4
+    set -u
 fi
 
 if [ "$(bower --version)" != '1.8.0' ]; then

--- a/install/nvm.sh
+++ b/install/nvm.sh
@@ -31,3 +31,4 @@ echo Close and reopen your terminal to start using nvm or run the following to u
 echo export NVM_DIR="$HOME/.nvm"
 echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm'
 
+exit 0

--- a/install/sdkman.sh
+++ b/install/sdkman.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 if [ -x "$HOME/.sdkman" ]; then
     source "$HOME/.sdkman/bin/sdkman-init.sh"
     sdk selfupdate

--- a/install/sdkman.sh
+++ b/install/sdkman.sh
@@ -8,7 +8,7 @@ else
 fi
 
 sdk install groovy 2.4.7
-sdk install grails 3.2.4
+sdk install gradle 3.3
 sdk install maven 3.3.9
 
 sdk flush candidates

--- a/install/sdkman.sh
+++ b/install/sdkman.sh
@@ -14,5 +14,5 @@ sdk install maven 3.3.9
 sdk flush candidates
 
 echo Please open a new terminal, or run the following in the existing one:
-echo source "/home/krupag/.sdkman/bin/sdkman-init.sh"
+echo source "$HOME/.sdkman/bin/sdkman-init.sh"
 

--- a/install/sdkman.sh
+++ b/install/sdkman.sh
@@ -2,18 +2,25 @@
 set -euo pipefail
 
 if [ -x "$HOME/.sdkman" ]; then
+    # SDKMAN doesn't play well in strict mode
+    set +eu
     source "$HOME/.sdkman/bin/sdkman-init.sh"
     sdk selfupdate
+    set -eu
 else
     curl -s "https://get.sdkman.io" | bash
+    set +u
     source "$HOME/.sdkman/bin/sdkman-init.sh"
+    set -u
 fi
 
+# SDKMAN doesn't play well in strict mode
+set +eu
 sdk install groovy 2.4.7
 sdk install gradle 3.3
 sdk install maven 3.3.9
-
 sdk flush candidates
+set -eu
 
 echo Please open a new terminal, or run the following in the existing one:
 echo source "$HOME/.sdkman/bin/sdkman-init.sh"

--- a/install/sdkman.sh
+++ b/install/sdkman.sh
@@ -18,3 +18,4 @@ sdk flush candidates
 echo Please open a new terminal, or run the following in the existing one:
 echo source "$HOME/.sdkman/bin/sdkman-init.sh"
 
+exit 0


### PR DESCRIPTION
## Description
Installation scripts for the following developer tools:
- Eclipse for Java Developers (Neon version)
- JetBrains ToolBox
- SDKMAN library/tool manager
  - Groovy
  - Gradle
  - Maven
- NVM Node.JS version manager
  - Grunt build tool
  - Bower library manager

## Motivation and Context
Provides a quick-start installation for common Java/JVM/JavaScript development tools
required to start working on Home Office projects.

## How Has This Been Tested?
- Tested on standard developer laptop by removing all pre-installed tools (and
  associated .bashrc/.bash_profile entries) and running the scripts, then re-running
  the scripts to ensure that pre-installed tools are not re-installed unnecessarily.
  
- Checked that all tools can be executed and functioning icons exist for all GUI tools
  in the Ubuntu Unity launcher.

- Code reviewed by Mat Perry.  Request additional review by merger.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.